### PR TITLE
enable styling override

### DIFF
--- a/ToggleSwitch.js
+++ b/ToggleSwitch.js
@@ -53,6 +53,10 @@ export default class ToggleSwitch extends React.Component {
     offColor: '#ecf0f1',
     size: 'medium',
     labelStyle: {},
+    thumbOnStyle: {},
+		thumbOffStyle: {},
+    trackOnStyle: {},
+		trackOffStyle: {},
     icon: null,
   }
 
@@ -65,6 +69,7 @@ export default class ToggleSwitch extends React.Component {
     borderRadius: 20,
     padding: this.dimensions.padding,
     backgroundColor: (this.props.isOn) ? this.props.onColor : this.props.offColor,
+    ...(this.props.isOn ? this.props.trackOnStyle : this.props.trackOffStyle)
   })
 
   createInsideCircleStyle = () => ({
@@ -77,6 +82,7 @@ export default class ToggleSwitch extends React.Component {
     width: this.dimensions.circleWidth,
     height: this.dimensions.circleHeight,
     borderRadius: (this.dimensions.circleWidth / 2),
+    ...(this.props.isOn ? this.props.thumbOnStyle : this.props.thumbOffStyle)
   });
 
   render() {


### PR DESCRIPTION
this way the style can be overriden for both tumb or track
```
<ToggleSwitch
					style={styles.setting_input}
					isOn={item.enabled == 1}
					onColor="white"
					thumbOnStyle={{ backgroundColor: 'blue' }}
					thumbOffStyle={{
						backgroundColor: 'rgba(255,255,255,0.5)',
						borderColor: 'blue',
						borderWidth: 1
					}}
					offColor="rgba(255,255,255,0.5)"
					size="large"
					onToggle={value => dispatch(updateSettings(item.name, value))}
				/>
```