### PR TITLE
Fix Animated: `useNativeDriver` was not specified.

### DIFF
--- a/ToggleSwitch.js
+++ b/ToggleSwitch.js
@@ -116,7 +116,7 @@ export default class ToggleSwitch extends React.Component {
 
     Animated.timing(this.offsetX, {
       toValue,
-      duration: 300
+      duration: 300,
       useNativeDriver: true,
     }).start();
 

--- a/ToggleSwitch.js
+++ b/ToggleSwitch.js
@@ -117,6 +117,7 @@ export default class ToggleSwitch extends React.Component {
     Animated.timing(this.offsetX, {
       toValue,
       duration: 300
+      useNativeDriver: true,
     }).start();
 
     return (


### PR DESCRIPTION
The new react-native animated API  requires `useNativeDriver`  property to be explicitly defined.