### PR TITLE
Fixed animation warning

### DIFF
--- a/ToggleSwitch.js
+++ b/ToggleSwitch.js
@@ -128,7 +128,8 @@ export default class ToggleSwitch extends React.Component {
 
     Animated.timing(this.offsetX, {
       toValue,
-      duration: this.props.animationSpeed
+      duration: this.props.animationSpeed,
+      useNativeDriver: true,
     }).start();
 
     return (


### PR DESCRIPTION
React native was returning a useNativeDrive warning when bundle the application.